### PR TITLE
Update doc build workflow to fetch all tags

### DIFF
--- a/.github/workflows/make-doc.yml
+++ b/.github/workflows/make-doc.yml
@@ -8,14 +8,15 @@ permissions:
 jobs:
   docs:
     runs-on: ubuntu-latest
+    if: startsWith(github.ref, 'refs/tags/') || github.ref == 'refs/heads/main' || github.ref == "refs/heads/dev-workflow"
     steps:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
+          fetch-tags: true
       - uses: actions/setup-python@v5
       - name: Install dependencies
         run: |
-          git status && git branch && git tag
           pip install -r requirements-dev.txt
       - name: Sphinx build
         run: |

--- a/.github/workflows/make-doc.yml
+++ b/.github/workflows/make-doc.yml
@@ -8,7 +8,7 @@ permissions:
 jobs:
   docs:
     runs-on: ubuntu-latest
-    if: startsWith(github.ref, 'refs/tags/') || github.ref == 'refs/heads/main' || github.ref == "refs/heads/dev-workflow"
+    if: startsWith(github.ref, 'refs/tags/') || github.ref == 'refs/heads/main' || github.ref == 'refs/heads/dev-workflow'
     steps:
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/make-doc.yml
+++ b/.github/workflows/make-doc.yml
@@ -13,6 +13,7 @@ jobs:
       - uses: actions/setup-python@v5
       - name: Install dependencies
         run: |
+          git status
           pip install -r requirements-dev.txt
       - name: Sphinx build
         run: |

--- a/.github/workflows/make-doc.yml
+++ b/.github/workflows/make-doc.yml
@@ -14,6 +14,8 @@ jobs:
       - name: Install dependencies
         run: |
           git status
+          git branch
+          git tag
           pip install -r requirements-dev.txt
       - name: Sphinx build
         run: |

--- a/.github/workflows/make-doc.yml
+++ b/.github/workflows/make-doc.yml
@@ -13,9 +13,7 @@ jobs:
       - uses: actions/setup-python@v5
       - name: Install dependencies
         run: |
-          git status
-          git branch
-          git tag
+          git status && git branch && git tag
           pip install -r requirements-dev.txt
       - name: Sphinx build
         run: |

--- a/.github/workflows/make-doc.yml
+++ b/.github/workflows/make-doc.yml
@@ -10,6 +10,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
       - uses: actions/setup-python@v5
       - name: Install dependencies
         run: |


### PR DESCRIPTION
The workflow that builds the documentation has been updated in order to clone the repo in the workflow using all tags and branches, allowing the sphinx plugin to build it for every matching tag/branch according to its configuration.